### PR TITLE
PLAT-42763 bump corretto17 to 17.0.2.8.1

### DIFF
--- a/Casks/corretto17.rb
+++ b/Casks/corretto17.rb
@@ -1,39 +1,27 @@
 cask "corretto17" do
-  version "17.0.0.35.2"
+  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+
+  version "17.0.2.8.1"
 
   if Hardware::CPU.intel?
-    sha256 "9363489f7fef6e109a977225e72dd5063d5e5dc5b1466f17f875eca4db8f4bae"
-
-    url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-x64.pkg"
-
-    livecheck do
-      url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-x64-macos-jdk.pkg"
-      strategy :header_match do |headers|
-        headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)*)-macosx-x64\.pkg}i, 1]
-      end
-    end
+    sha256 "8856ff07f1b225b7444bf30aea69963641ad18a27312ce2770512b1a4d5ced5b"
   else
-    sha256 "64083bd91f60bb9481c61c9484aacbd59d6776bb5fb3229d3ea2c6a2236d0a8b"
-
-    url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-aarch64.pkg"
-
-    livecheck do
-      url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-aarch64-macos-jdk.pkg"
-      strategy :header_match do |headers|
-        headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)*)-macosx-aarch64\.pkg}i, 1]
-      end
-    end
+    sha256 "182dd6a5064d5a4135b82bca6293f1d557d5c48ba64bf0e05c931153ba06802c"
   end
 
+  url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "AWS Corretto JDK"
   desc "OpenJDK distribution from Amazon"
   homepage "https://corretto.aws/"
 
-  if Hardware::CPU.intel?
-    pkg "amazon-corretto-#{version}-macosx-x64.pkg"
-  else
-    pkg "amazon-corretto-#{version}-macosx-aarch64.pkg"
+  livecheck do
+    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch}-macos-jdk.pkg"
+    strategy :header_match do |headers|
+      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i, 1]
+    end
   end
+
+  pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
 end


### PR DESCRIPTION
Bump corretto 17 Cask (macOS only) to `17.0.2.8.1`.