### PR TITLE
PLAT-42830 bump corretto8 to 8.322.06

### DIFF
--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,20 +1,27 @@
 cask "corretto8" do
-  version "8.302.08.1"
-  sha256 "4a9f0c6d1ddb04a68f5ccd22e0f15893f5bbdae66c82b16b3599e87db23316cb"
+  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
+  if Hardware::CPU.intel?
+    version "8.322.06.1"
+    sha256 "c20d7454fc0b461d3d354b6d4eed2665fa056d74ef438ef51c26f140203b4386"
+  else
+    version "8.322.06.4"
+    sha256 "bbca6e00d81070f7c633fbede651ae6bfa71cbc563d250ee2e0c439e69a3e193"
+  end
+
+  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "Amazon Corretto JDK"
   desc "OpenJDK distribution from Amazon"
   homepage "https://corretto.aws/"
 
   livecheck do
-    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-x64-macos-jdk.pkg"
+    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch}-macos-jdk.pkg"
     strategy :header_match do |headers|
-      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)*)-macosx-x64\.pkg}i, 1]
+      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i, 1]
     end
   end
 
-  pkg "amazon-corretto-#{version}-macosx-x64.pkg"
+  pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
 end


### PR DESCRIPTION
Bump corretto8 to 8.322.06, which adds support for Intel and non-Intel architectures.