### PR TITLE
PLAT-47266 update corretto casks for 8, 11, and 17

### DIFF
--- a/Casks/corretto11.rb
+++ b/Casks/corretto11.rb
@@ -1,14 +1,27 @@
 cask "corretto11" do
-  version "11.0.12.7.2"
-  sha256 "90a6829e61e60c04c9207d0c2543c5781a4c05c0cbf84868a33de5bbf3eb7741"
+  arch arm: "aarch64", intel: "x64"
 
-  url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-x64.pkg"
-  appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://corretto.aws/downloads/latest/amazon-corretto-11-x64-macos-jdk.pkg"
-  name "Amazon Corretto JDK"
+  version "11.0.16.9.1"
+
+  on_intel do
+    sha256 "1b256d7104ebc0f72d7745962e0ab47cbbbd976f93481f31bd4a7d40812d739a"
+  end
+  on_arm do
+    sha256 "a460362f97e5371221e76386ea08ba0773c524f8ce7a2f85cb398b62f5c28aca"
+  end
+
+  url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
+  name "AWS Corretto JDK"
   desc "OpenJDK distribution from Amazon"
   homepage "https://corretto.aws/"
 
-  pkg "amazon-corretto-#{version}-macosx-x64.pkg"
+  livecheck do
+    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch}-macos-jdk.pkg"
+    regex(%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i)
+    strategy :header_match
+  end
+
+  pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
 end

--- a/Casks/corretto17.rb
+++ b/Casks/corretto17.rb
@@ -1,12 +1,13 @@
 cask "corretto17" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+  arch arm: "aarch64", intel: "x64"
 
-  version "17.0.2.8.1"
+  version "17.0.4.9.1"
 
-  if Hardware::CPU.intel?
-    sha256 "8856ff07f1b225b7444bf30aea69963641ad18a27312ce2770512b1a4d5ced5b"
-  else
-    sha256 "182dd6a5064d5a4135b82bca6293f1d557d5c48ba64bf0e05c931153ba06802c"
+  on_intel do
+    sha256 "a91db130cbf99ab993d5d579a71ee7cd7c2682c2b6698d9353db1a5393b01f7f"
+  end
+  on_arm do
+    sha256 "d46bf6798a54c283cc4297dc86cb0173571b7dfc70b3609846911bb5ac3ffdb8"
   end
 
   url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
@@ -16,9 +17,8 @@ cask "corretto17" do
 
   livecheck do
     url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch}-macos-jdk.pkg"
-    strategy :header_match do |headers|
-      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i, 1]
-    end
+    regex(%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i)
+    strategy :header_match
   end
 
   pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"

--- a/Casks/corretto8.rb
+++ b/Casks/corretto8.rb
@@ -1,12 +1,13 @@
 cask "corretto8" do
-  arch = Hardware::CPU.intel? ? "x64" : "aarch64"
+  arch arm: "aarch64", intel: "x64"
 
-  if Hardware::CPU.intel?
-    version "8.322.06.1"
-    sha256 "c20d7454fc0b461d3d354b6d4eed2665fa056d74ef438ef51c26f140203b4386"
-  else
-    version "8.322.06.4"
-    sha256 "bbca6e00d81070f7c633fbede651ae6bfa71cbc563d250ee2e0c439e69a3e193"
+  version "8.342.07.3"
+
+  on_intel do
+    sha256 "5bde0f3682e9f809d620220bbca414a3493af41ce219509d840b17da85e0070a"
+  end
+  on_arm do
+    sha256 "159d27625838c12f0fa6f6edc7b3c50924362f022c4490605f3798d947bcf9bf"
   end
 
   url "https://corretto.aws/downloads/resources/#{version}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
@@ -16,9 +17,8 @@ cask "corretto8" do
 
   livecheck do
     url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch}-macos-jdk.pkg"
-    strategy :header_match do |headers|
-      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i, 1]
-    end
+    regex(%r{/amazon-corretto-(\d+(?:\.\d+)+)-macosx-#{arch}\.pkg}i)
+    strategy :header_match
   end
 
   pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"


### PR DESCRIPTION
Snapshot of [homebrew cask versions](https://github.com/Homebrew/homebrew-cask-versions)
- 8.342.07.3
- 11.0.16.9.1
- 17.0.4.9.1
