### PR TITLE
PLAT-80462 extend yq@3 to align with EOL for 7.*

### DIFF
--- a/Formula/yq@3.rb
+++ b/Formula/yq@3.rb
@@ -15,7 +15,7 @@ class YqAT3 < Formula
 
   keg_only :versioned_formula
 
-  disable! date: "2023-12-31", because: :unmaintained
+  disable! date: "2024-12-31", because: :unmaintained
 
   depends_on "go" => :build
 


### PR DESCRIPTION
Extends `yq@3` to end of 2024 at which point 7.* support will end.