### PR TITLE
PLAT-90927 custom brew-gem without ruby dependency

### DIFF
--- a/Formula/brew-gem.rb
+++ b/Formula/brew-gem.rb
@@ -1,0 +1,34 @@
+class BrewGem < Formula
+  desc "Install RubyGems as Homebrew formulae"
+  homepage "https://github.com/sportngin/brew-gem"
+  url "https://github.com/sportngin/brew-gem/archive/refs/tags/v1.1.1.tar.gz"
+  sha256 "affa68105dcabc5c8b4832cf70ee2b35c1fbf19496173753645bda496d9b0a34"
+  license "MIT"
+  head "https://github.com/sportngin/brew-gem.git", branch: "master"
+
+  # Until versions exceed 2.2, the leading `v` in this regex isn't optional, as
+  # we need to avoid an older `2.2` tag (a typo) while continuing to match
+  # newer tags like `v1.1.1` and allowing for a future `v2.2.0` version.
+  livecheck do
+    url :stable
+    regex(/^v(\d+(?:\.\d+)+)$/i)
+  end
+
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "fc319ba05f5f17b0f516292f5fb2d55eccb6c03a11cacc438b1c2c2fb5ccb0db"
+  end
+
+  # see PLAT-90927
+  # uses_from_macos "ruby"
+
+  def install
+    inreplace "lib/brew/gem/formula.rb.erb", "/usr/local", HOMEBREW_PREFIX
+
+    lib.install Dir["lib/*"]
+    bin.install "bin/brew-gem"
+  end
+
+  test do
+    system "#{bin}/brew-gem", "help"
+  end
+end


### PR DESCRIPTION
Removes the problematic, floating, `ruby` dependency that broke the `brew-gem` formula.

Note: this assumes the specific `ruby` dependency is managed outside!