### PR TITLE
add old and new version format for corretto 17

### DIFF
--- a/Casks/corretto@17.rb
+++ b/Casks/corretto@17.rb
@@ -1,14 +1,9 @@
-cask "corretto17" do
+cask "corretto@17" do
   arch arm: "aarch64", intel: "x64"
 
-  version "17.0.4.9.1"
-
-  on_intel do
-    sha256 "a91db130cbf99ab993d5d579a71ee7cd7c2682c2b6698d9353db1a5393b01f7f"
-  end
-  on_arm do
-    sha256 "d46bf6798a54c283cc4297dc86cb0173571b7dfc70b3609846911bb5ac3ffdb8"
-  end
+  version "17.0.11.9.1"
+  sha256 arm:   "6e757c22fbe62ea7cefe6465c79bf6c0e9230121d3127633144ceca0f8b48eec",
+         intel: "76f3fb3ea4de49c054236ab0c00ec8e7a74f5336ceb5a13f234448ab0457c2eb"
 
   url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "AWS Corretto JDK"
@@ -24,4 +19,6 @@ cask "corretto17" do
   pkg "amazon-corretto-#{version}-macosx-#{arch}.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
+
+  # No zap stanza required
 end


### PR DESCRIPTION
Provides a migration path that #16 would have broken.